### PR TITLE
Fix issue installing from Pypi with MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include pyutu/_version

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 
 setup(
     name='pyutu',
-    version=open(os.path.join('pyutu', '_version')).read().strip(),
+    version=open('_version').read().strip(),
     url='https://github.com/lashex/pyutu',
     license=open("LICENSE").read(),
     author='Brett Francis',


### PR DESCRIPTION
some setup.py requirements are missing from the package as per:

-> % pip install pyutu
Collecting pyutu
  Using cached pyutu-0.4.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/py/jfww5c650hd3m_2q4r1bv7680000gn/T/pip-build-Qc4Dw7/pyutu/setup.py", line 12, in <module>
        version=open(os.path.join('pyutu', '_version')).read().strip(),
    IOError: [Errno 2] No such file or directory: 'pyutu/_version'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/py/jfww5c650hd3m_2q4r1bv7680000gn/T/pip-build-Qc4Dw7/pyutu/